### PR TITLE
Allow to use actual words as image class in output file

### DIFF
--- a/src/main/java/de/lmu/ifi/dbs/jfeaturelib/utils/Extractor.java
+++ b/src/main/java/de/lmu/ifi/dbs/jfeaturelib/utils/Extractor.java
@@ -401,8 +401,9 @@ public class Extractor {
         }
 
         // check if an image class is set and valid
-        if (imageClass != null && !imageClass.matches("^\\w$")) {
-            throw new IllegalArgumentException("the image class must only contain word characters");
+        if (imageClass != null && !imageClass.matches("^\\w+$")) {
+            throw new IllegalArgumentException(
+                    "the image class must only contain word characters and not whitespace");
         }
     }
 


### PR DESCRIPTION
When calling JFeatureLib from command line using the -c option, it is only possible to define a single character as class. The patch allows to use any word as class label and improves the error message.
