### PR TITLE
Catch Throwable in ExtractionTask

### DIFF
--- a/src/main/java/de/lmu/ifi/dbs/jfeaturelib/utils/Extractor.java
+++ b/src/main/java/de/lmu/ifi/dbs/jfeaturelib/utils/Extractor.java
@@ -639,6 +639,8 @@ public class Extractor {
                 writeOutput(image, features);
             } catch (IOException | InstantiationException | IllegalAccessException ex) {
                 log.warn(ex.getMessage(), ex);
+            } catch (Throwable ex) {
+                log.error(ex.getMessage(), ex);
             }
         }
 


### PR DESCRIPTION
This ensures that all exceptions that might occur during processing are logged
