### PR TITLE
Fix IndexOutOfBoundsException when retrieving min and max from image

### DIFF
--- a/src/main/java/de/lmu/ifi/dbs/jfeaturelib/features/MeanPatchIntensityHistogram.java
+++ b/src/main/java/de/lmu/ifi/dbs/jfeaturelib/features/MeanPatchIntensityHistogram.java
@@ -97,6 +97,9 @@ public class MeanPatchIntensityHistogram extends AbstractFeatureDescriptor {
 
         if (m_histMin == 0 && m_histMax == 0) {
             retrieveMinAndMaxFromImage(ip);
+            // Histogram class excludes the maximum value,
+            // therefore increase it by 1
+            m_histMax++;
         }
 
         Histogram hist = new Histogram(m_bins, m_histMin, m_histMax);


### PR DESCRIPTION
The histogram class does excludes the max value, hence an exception occurs when we try to add the maximum value. This fix increases the max value by 1 when min/max are retrieved from the image.
